### PR TITLE
play=>plays for the correct api call

### DIFF
--- a/notebooks/5_Exploring_Programmable_Corpora/5-2_Exploring_Programmable_Corpora_Advanced/5-2-2_catch-a-protagonist-in-dracor.ipynb
+++ b/notebooks/5_Exploring_Programmable_Corpora/5-2_Exploring_Programmable_Corpora_Advanced/5-2-2_catch-a-protagonist-in-dracor.ipynb
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We don't know anything about the network metrics of the whole play, though. If we want to retrieve this information, we would have to use the API function `/corpora/{corpusname}/play/{playname}/metrics`, which would also tell us, if there are several sub-networks in a dictionary-field with the key `numConnectedComponents`. This could be relevant, because we can also calculate some network-metrics differently, e.g. the *closeness*."
+    "We don't know anything about the network metrics of the whole play, though. If we want to retrieve this information, we would have to use the API function `/corpora/{corpusname}/plays/{playname}/metrics`, which would also tell us, if there are several sub-networks in a dictionary-field with the key `numConnectedComponents`. This could be relevant, because we can also calculate some network-metrics differently, e.g. the *closeness*."
    ]
   },
   {


### PR DESCRIPTION
it seems the correct way to get play metrics in the current version of the DraCor API is `/corpora/{corpusname}/plays/{playname}/metrics`, not `/corpora/{corpusname}/play/{playname}/metrics`